### PR TITLE
updated readme for running kaggle.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Note: you'll wanna run this on a GPU rig with some RAM. I'm using a 1080ti and 1
 - Download [mczielinski/bitcoin-historical-data](https://www.kaggle.com/mczielinski/bitcoin-historical-data)
 - Extract to `data/populate/bitcoin-historical-data`
 - `python data/populate/kaggle.py`
+  - if you get `ModuleNotFoundError: No module named 'data.data'`, run `PYTHONPATH=. python data/populate/kaggle.py`
 - `python -c 'from data.data import setup_runs_table;setup_runs_table()'`
   - If you have trouble with that, just copy/paste the SQL from that file, execute against your `hyper_runs` DB from above.
 


### PR DESCRIPTION
quick fix for the following issue:

```Traceback (most recent call last):
  File "data/populate/kaggle.py", line 10, in <module>
    from data.data import engine
ModuleNotFoundError: No module named 'data.data'```