### PR TITLE
Save trials (pickle) 

### DIFF
--- a/hypersearch.py
+++ b/hypersearch.py
@@ -346,7 +346,7 @@ def main():
     # grab how many trials were previously run and add max_evals to it for the next run.
     # this allows the hyper parameter search to resume where it left off last.
     # TODO save trials to SQL table and restore from there instead of local pickle. 
-    max_evals = 1
+    max_evals = 20
     try:
         trialPickle = open('./trial.pickle','rb')
         trials = pickle.load(trialPickle)


### PR DESCRIPTION
Keeps the progress of the hypersearch in a local pickle file saved at end of max_evals so the next run of hypersearch picks up where the last left off. See issue #39 for additional information and limitations.